### PR TITLE
Fix frozen Gemfile.lock when overriding gem version

### DIFF
--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -28,11 +28,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4.7
-          bundler-cache: true
+          bundler-cache: ${{ !inputs.rspec_trunk_flaky_tests_version }}
 
-      - name: Update rspec_trunk_flaky_tests
+      - name: Install dependencies with custom gem version
         if: ${{ inputs.rspec_trunk_flaky_tests_version }}
-        run: bundle update rspec_trunk_flaky_tests
+        run: bundle install
 
       # this is the recommended way to run rspec tests using the trunk rspec plugin
       - name: Run rspec tests (with trunk rspec plugin)


### PR DESCRIPTION
## Summary
- Disable `bundler-cache` when a custom `rspec_trunk_flaky_tests_version` is specified
- Run `bundle install` manually instead, which allows updating the lockfile

This fixes the frozen lockfile error when using workflow_dispatch with a custom gem version.

## Test plan
- [ ] Manually trigger workflow with a specific version (e.g., `0.12.9.pre.beta.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)