### PR TITLE
feat: wire test collection IDs to all upload steps

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -65,3 +65,4 @@ jobs:
           org-slug: ${{ vars.ORG_SLUG }}
           token: ${{ secrets.TRUNK_TOKEN }}
           previous-step-outcome: ${{ matrix.bep_format == 'binary' && steps.run_tests_binary.outcome || steps.run_tests_json.outcome }}
+          test-collection-short-id: yYmFApb3

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -65,4 +65,4 @@ jobs:
           org-slug: ${{ vars.ORG_SLUG }}
           token: ${{ secrets.TRUNK_TOKEN }}
           previous-step-outcome: ${{ matrix.bep_format == 'binary' && steps.run_tests_binary.outcome || steps.run_tests_json.outcome }}
-          test-collection-short-id: yYmFApb3
+          test-collection-id: yYmFApb3

--- a/.github/workflows/csharp-tests.yaml
+++ b/.github/workflows/csharp-tests.yaml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
-          test-collection-short-id: TRswS5p1
+          test-collection-id: TRswS5p1
 
       - name: Upload test results
         if: always() # Always run this step to upload results

--- a/.github/workflows/csharp-tests.yaml
+++ b/.github/workflows/csharp-tests.yaml
@@ -44,6 +44,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
+          test-collection-short-id: TRswS5p1
 
       - name: Upload test results
         if: always() # Always run this step to upload results

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
-          test-collection-short-id: KOq4cED4
+          test-collection-id: KOq4cED4
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -52,6 +52,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
+          test-collection-short-id: KOq4cED4
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -51,7 +51,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
-          test-collection-short-id: VOlVhbH7
+          test-collection-id: VOlVhbH7
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -51,6 +51,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
+          test-collection-short-id: VOlVhbH7
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.mocha_tests.outcome }}
-          test-collection-short-id: 2gyJClZi
+          test-collection-id: 2gyJClZi
 
       - name: Run Jest Tests
         id: jest_tests
@@ -71,7 +71,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.jest_tests.outcome }}
-          test-collection-short-id: 2gyJClZi
+          test-collection-id: 2gyJClZi
 
       - name: Run Jasmine Tests
         id: jasmine_tests
@@ -93,7 +93,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.jasmine_tests.outcome }}
-          test-collection-short-id: 2gyJClZi
+          test-collection-id: 2gyJClZi
 
       - name: Run Playwright Tests
         id: playwright_tests
@@ -115,7 +115,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.playwright_tests.outcome }}
-          test-collection-short-id: 2gyJClZi
+          test-collection-id: 2gyJClZi
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -49,6 +49,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.mocha_tests.outcome }}
+          test-collection-short-id: 2gyJClZi
 
       - name: Run Jest Tests
         id: jest_tests
@@ -70,6 +71,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.jest_tests.outcome }}
+          test-collection-short-id: 2gyJClZi
 
       - name: Run Jasmine Tests
         id: jasmine_tests
@@ -91,6 +93,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.jasmine_tests.outcome }}
+          test-collection-short-id: 2gyJClZi
 
       - name: Run Playwright Tests
         id: playwright_tests
@@ -112,6 +115,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.playwright_tests.outcome }}
+          test-collection-short-id: 2gyJClZi
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
-          test-collection-short-id: Qvu4CYQ1
+          test-collection-id: Qvu4CYQ1
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -46,6 +46,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
+          test-collection-short-id: Qvu4CYQ1
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -54,6 +54,7 @@ jobs:
           variant: ${{ matrix.variant }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.pytest_tests.outcome }}
+          test-collection-short-id: 4hNhoz4T
 
       - name: Run robotframework tests
         id: robotframework_tests
@@ -80,6 +81,7 @@ jobs:
           variant: ${{ matrix.variant }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.robotframework_tests.outcome }}
+          test-collection-short-id: 4hNhoz4T
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -54,7 +54,7 @@ jobs:
           variant: ${{ matrix.variant }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.pytest_tests.outcome }}
-          test-collection-short-id: 4hNhoz4T
+          test-collection-id: 4hNhoz4T
 
       - name: Run robotframework tests
         id: robotframework_tests
@@ -81,7 +81,7 @@ jobs:
           variant: ${{ matrix.variant }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.robotframework_tests.outcome }}
-          test-collection-short-id: 4hNhoz4T
+          test-collection-id: 4hNhoz4T
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/retry-tests.yaml
+++ b/.github/workflows/retry-tests.yaml
@@ -57,6 +57,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
+          test-collection-short-id: ngDMB4ln
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/retry-tests.yaml
+++ b/.github/workflows/retry-tests.yaml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.run_tests.outcome }}
-          test-collection-short-id: ngDMB4ln
+          test-collection-id: ngDMB4ln
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -67,7 +67,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.rspec_tests.outcome }}
-          test-collection-short-id: SrV9Xppx
+          test-collection-id: SrV9Xppx
 
       - name: Run minitest tests
         id: minitest_tests
@@ -90,7 +90,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.minitest_tests.outcome }}
-          test-collection-short-id: SrV9Xppx
+          test-collection-id: SrV9Xppx
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -67,6 +67,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.rspec_tests.outcome }}
+          test-collection-short-id: SrV9Xppx
 
       - name: Run minitest tests
         id: minitest_tests
@@ -89,6 +90,7 @@ jobs:
           token: ${{ secrets.TRUNK_TOKEN }}
           # Pass the test outcome for quarantining support
           previous-step-outcome: ${{ steps.minitest_tests.outcome }}
+          test-collection-short-id: SrV9Xppx
 
       - name: Upload JUnit XML artifacts
         if: ${{ always() }}

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           ./trunk-analytics-cli test \
             --org-url-slug ${{ vars.ORG_SLUG }} \
-            --test-collection-short-id eh3CZSJD \
+            --test-collection-id eh3CZSJD \
             --junit-paths "rust/**/nextest/ci/*junit.xml" \
             -- cargo nextest run --profile=ci --manifest-path=./rust/Cargo.toml
 

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           ./trunk-analytics-cli test \
             --org-url-slug ${{ vars.ORG_SLUG }} \
+            --test-collection-short-id eh3CZSJD \
             --junit-paths "rust/**/nextest/ci/*junit.xml" \
             -- cargo nextest run --profile=ci --manifest-path=./rust/Cargo.toml
 


### PR DESCRIPTION
## Summary

Wires Trunk Flaky Tests collection IDs to all test upload steps across repos, enabling per-collection flake tracking rather than repo-wide tracking. Adds both staging and prod collection IDs where applicable. Depends on the `--test-collection-id` CLI flag rename landing first.

## PRs

- [ ] trunk-io/analytics-cli#1119
- [ ] trunk-io/analytics-uploader#138
- [ ] trunk-io/trunk2#4188
- [ ] trunk-io/trunk#32649
- [ ] trunk-io/flake-farm#20280
- [ ] trunk-io/flake-farm-staging-fork-prs#283
- [ ] trunk-io/flake-farm-staging-fork-prs-generator#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)