### PR TITLE
Enable use-bazel-target-for-codeowners for Bazel BEP uploads

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -62,6 +62,7 @@ jobs:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
           bazel-bep-path: ${{ matrix.bep_format == 'binary' && 'bep.bin' || 'build_events.json' }}
+          use-bazel-target-for-codeowners: true
           org-slug: ${{ vars.ORG_SLUG }}
           token: ${{ secrets.TRUNK_TOKEN }}
           previous-step-outcome: ${{ matrix.bep_format == 'binary' && steps.run_tests_binary.outcome || steps.run_tests_json.outcome }}


### PR DESCRIPTION
Enables \`use-bazel-target-for-codeowners: true\` in the Bazel BEP upload workflow so that Bazel target labels are used as a fallback path for CODEOWNERS association when no \`file\` attribute is present in the JUnit XML.

## Related PRs

- https://github.com/trunk-io/trunk/pull/32673
- https://github.com/trunk-io/flake-farm/pull/20345
- https://github.com/trunk-io/flake-farm-staging-fork-prs/pull/339
- https://github.com/trunk-io/flake-farm-staging-fork-prs-generator/pull/4