### PR TITLE
Wire pre-release smoke-test version vars into CI

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -63,6 +63,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           bazel-bep-path: ${{ matrix.bep_format == 'binary' && 'bep.bin' || 'build_events.json' }}
           use-bazel-target-for-codeowners: true
           org-slug: ${{ vars.ORG_SLUG }}

--- a/.github/workflows/csharp-tests.yaml
+++ b/.github/workflows/csharp-tests.yaml
@@ -35,6 +35,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           # This path should match the LogFilePath used in the dotnet test command.
           junit-paths: csharp/**/test-results/csharp-junit.xml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,6 +44,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/go-*_test.xml"
           # Provide your Trunk organization slug.

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -42,6 +42,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths:
             "**/gradle/**/test-results/**/*.xml,**/surefire-reports/*.xml,**/playwright/**/surefire-reports/*.xml"

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -41,6 +41,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: javascript/tests/mocha/mocha_test.xml
           # Provide your Trunk organization slug.
@@ -63,6 +64,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/junitresults-*.xml"
           # Provide your Trunk organization slug.
@@ -85,6 +87,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/*_test.xml"
           # Provide your Trunk organization slug.
@@ -107,6 +110,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: tests/playwright/junitresults-playwright.xml
           # Provide your Trunk organization slug.

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -38,6 +38,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/*_test.xml"
           # Provide your Trunk organization slug.

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -44,6 +44,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: python/results/pytest/pytest_test.xml
           # Provide your Trunk organization slug.
@@ -71,6 +72,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: python/results/robotframework/robot_test.xml
           # Provide your Trunk organization slug.

--- a/.github/workflows/retry-tests.yaml
+++ b/.github/workflows/retry-tests.yaml
@@ -49,6 +49,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/python/results/*-behave.xml"
           # Provide your Trunk organization slug.

--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -34,6 +34,14 @@ jobs:
         if: ${{ inputs.rspec_trunk_flaky_tests_version }}
         run: bundle install
 
+      - name: Optionally pin pre-release trunk rspec gem
+        if: vars.RSPEC_PRE_RELEASE_TEST_VERSION != '' && vars.RSPEC_PRE_RELEASE_TEST_VERSION != 'latest'
+        run: |
+          VERSION='${{ vars.RSPEC_PRE_RELEASE_TEST_VERSION }}'
+          sed -i "s/^gem 'rspec_trunk_flaky_tests'.*/gem 'rspec_trunk_flaky_tests', '= ${VERSION}'/" Gemfile
+          bundle config set --local frozen false
+          bundle install
+
       # this is the recommended way to run rspec tests using the trunk rspec plugin
       - name: Run rspec tests (with trunk rspec plugin)
         id: rspec_trunk_tests
@@ -59,6 +67,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/rspec_test.xml"
           # Provide your Trunk organization slug.
@@ -82,6 +91,7 @@ jobs:
         env:
           TRUNK_PUBLIC_API_ADDRESS: ${{ vars.TRUNK_API_ENDPOINT }}
         with:
+          cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
           # Path to your test results.
           junit-paths: "**/ruby/minitest/results/*.xml"
           # Provide your Trunk organization slug.

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -22,7 +22,7 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Install trunk-analytics-cli
-        run: bash get-trunk-cli
+        run: bash get-trunk-cli "${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}"
 
       - name: Run rust tests
         id: run_tests

--- a/get-trunk-cli
+++ b/get-trunk-cli
@@ -6,6 +6,9 @@ set -euo pipefail
 
 REPO="trunk-io/analytics-cli"
 
+# Optional pre-release version to smoke-test ("" or "latest" = latest release).
+VERSION="${1:-}"
+
 # Normalize OS/arch to match launcher script platform naming
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')" # linux | darwin
 ARCH="$(uname -m)"
@@ -35,7 +38,11 @@ else
 fi
 
 ASSET="trunk-analytics-cli-${PLATFORM}.tar.gz"
-URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+if [[ -n ${VERSION} && ${VERSION} != "latest" ]]; then
+	URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+else
+	URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+fi
 
 echo "Downloading and installing ${ASSET}…"
 curl -fL --retry 3 "${URL}" | tar -xz


### PR DESCRIPTION
## Goal

Let two org-wide GitHub Actions variables pin CI to a specific (usually pre-release) build for smoke-testing, without code changes. Both default to **off** (unset/empty/`latest` → the literal latest), and when off, behavior is unchanged.

| Variable | Controls |
|---|---|
| `ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION` | analytics CLI version |
| `RSPEC_PRE_RELEASE_TEST_VERSION` | `rspec_trunk_flaky_tests` gem version |

## Flows in scope (both used by this repo)

### Flow A — analytics CLI
flake-farm has **no local composite actions**, so there's no threading — the var is passed directly at each call site.

- **`trunk-io/analytics-uploader@main` (action):** added `cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}` to every call site. The uploader resolves `latest` itself, so an empty var is a no-op (no ternary/fallback).
- **Rust (raw CLI):** `rust-tests.yaml` uploads with `./trunk-analytics-cli` downloaded by `get-trunk-cli`, not the uploader action. `get-trunk-cli` now takes an optional version arg and downloads `releases/download/<version>/…` for a concrete version, else `releases/latest/download/…`. Both an empty arg **and** the literal `latest` map to the latest path, matching the off-semantics. `rust-tests.yaml` passes the var. *(Wiring the CLI-direct path was confirmed in scope; it's a mechanism beyond the standard uploader convention.)*

**Call sites — wired vs found (match):**

| workflow | analytics-uploader sites |
|---|---|
| bazel | 1 |
| csharp-tests | 1 |
| go | 1 |
| java-tests | 1 |
| javascript-tests | 4 |
| php | 1 |
| python-tests | 2 |
| retry-tests | 1 |
| ruby-tests | 2 |
| **total** | **14 found / 14 wired** |

Plus the 1 rust CLI-direct path (`get-trunk-cli` + `rust-tests.yaml`).

### Flow B — rspec gem
`ruby-tests.yaml` runs the trunk rspec plugin **inline** (`bundle exec rspec` in `ruby/trunk_rspec`; the gem is `gem 'rspec_trunk_flaky_tests', '~> 0.12.5'` in the root `Gemfile`). Added an inline guarded step **after** bundle install / **before** the rspec run that pins the gem to `= <version>`, disables frozen mode, and re-resolves. `sed` adapted to the repo's single-quote style; `= <version>` (bundler skips pre-releases otherwise) and `bundle config set --local frozen false` (setup-ruby's `bundler-cache` installs frozen) are both required. No Gemfile/lock change is committed.

## Behavior changes

- **None when the vars are off.** No `LATEST_RELEASE` / "Find latest release" pin existed in this repo, so nothing was dropped and the off-state (latest) is preserved on every path — including `get-trunk-cli`, which treats empty **and** `latest` as the latest release.
- The pre-existing manual-dispatch `inputs.rspec_trunk_flaky_tests_version` override in `ruby-tests.yaml` is a separate, still-working feature and is **left intact**; the new vars flow is added alongside it.

## Excluded / out of scope

No onboarding templates, docs/TRDs, test fixtures, server code, or plugins-style `upload-linter-versions` exist in this repo, so none were touched. The plain `bundle exec rspec ruby/rspec` run doesn't use the trunk plugin (the shared Gemfile pin still applies harmlessly).

## Notes

- **Formatting matched by hand:** the sandbox proxy blocks `get.trunk.io`, so `trunk fmt` / `trunk check` could not run locally. Relying on the repo's own Trunk Check in CI.
- **`get-trunk-cli` versioned URL** assumes a concrete version string equals the release tag under `trunk-io/analytics-cli/releases/download/<version>/`. Worth a sanity check against how the uploader resolves `cli-version` → a tag; it only affects the on-state with a concrete version set, so the off-state (empty/`latest`) is unaffected regardless.

Please review — **not for merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)