### PR TITLE
Add spec for pending and skip example handling in trunk rspec

### DIFF
--- a/ruby/trunk_rspec/spec/pending_spec.rb
+++ b/ruby/trunk_rspec/spec/pending_spec.rb
@@ -1,0 +1,28 @@
+# spec/pending_spec.rb
+# Exercises how the trunk rspec plugin reports pending/skip examples.
+# RSpec inverts a pending example's outcome, so the reported status is:
+#   skip / xit                  -> skipped
+#   pending, body still failing -> success
+#   pending, body now passing   -> failure (PendingExampleFixedError)
+require_relative "../lib/calculator"
+
+describe "TrunkCalculator pending and skip handling" do
+  it "reports an explicit skip as skipped" do
+    skip("not ready yet")
+    expect(TrunkCalculator.add(1, 1)).to eq(3)
+  end
+
+  xit "reports xit as skipped" do
+    expect(TrunkCalculator.add(1, 1)).to eq(3)
+  end
+
+  it "reports a still-broken pending example as success" do
+    pending("halve truncates instead of returning a float")
+    expect(TrunkCalculator.halve(3)).to eq(1.5)
+  end
+
+  it "reports a fixed pending example as failure" do
+    pending("expected to still fail, but the body now passes")
+    expect(TrunkCalculator.add(1, 2)).to eq(3)
+  end
+end


### PR DESCRIPTION
## Summary

Seeing results here https://github.com/trunk-io/flake-farm/actions/runs/29036655722/job/86183155093?pr=20894
Proper fix to handle quarantine https://github.com/trunk-io/flake-farm/actions/runs/29036655722/job/86398149303#step:7:37

Added a comprehensive test suite to document and verify how the trunk rspec plugin reports pending and skipped examples.

## Key Changes
- Added `spec/pending_spec.rb` with test cases covering four scenarios:
  - Explicit `skip()` calls are reported as skipped
  - `xit` (disabled tests) are reported as skipped
  - Pending examples with still-failing assertions are reported as success
  - Pending examples with now-passing assertions are reported as failure (PendingExampleFixedError)

## Notable Details
This spec serves as documentation for RSpec's inverted pending example behavior, where:
- Skip/xit examples result in a "skipped" status
- Pending examples that still fail are treated as passing (the pending expectation is met)
- Pending examples that now pass are treated as failing (PendingExampleFixedError is raised, indicating the issue has been fixed)

The tests use the `TrunkCalculator` class to exercise real calculator operations alongside the pending/skip semantics.

https://claude.ai/code/session_01DwtczN5m1j8MtzFqdLdB7x