### PR TITLE
Add Playwright retry tests for flaky test detection

### DIFF
--- a/bazel/python/tests/stock_data_test.py
+++ b/bazel/python/tests/stock_data_test.py
@@ -7,7 +7,6 @@ import sys
 import time
 import traceback
 import unittest
-import xml.etree.ElementTree as ET
 
 from bazel.python.src.stock_data import RateLimitError, StockData, StockDataManager
 
@@ -141,44 +140,63 @@ def _summary_line(message: str) -> str:
     return ""
 
 
+def _xml_escape(text: str) -> str:
+    """Escape a string for use in XML text or double-quoted attribute values."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
 def _write_junit_xml(
     output_path: str, result: _RecordingResult, total_time: float
 ) -> None:
-    """Write one <testcase> per ticker so Bazel/Trunk track each ticker as a distinct test."""
+    """Write one <testcase> per ticker so Bazel/Trunk track each ticker as a distinct test.
+
+    Built as a plain string (no XML parser is involved) since we only emit trusted output.
+    """
     outcomes = [outcome for _, outcome, _, _, _ in result.records]
-    testsuites = ET.Element("testsuites")
-    testsuite = ET.SubElement(
-        testsuites,
-        "testsuite",
-        {
-            "name": "StockDataTest",
-            "tests": str(len(result.records)),
-            "failures": str(outcomes.count("failure")),
-            "errors": str(outcomes.count("error")),
-            "skipped": str(outcomes.count("skipped")),
-            "time": f"{total_time:.3f}",
-        },
+    lines = ['<?xml version="1.0" encoding="utf-8"?>']
+    lines.append(
+        '<testsuites><testsuite name="StockDataTest" '
+        f'tests="{len(result.records)}" '
+        f'failures="{outcomes.count("failure")}" '
+        f'errors="{outcomes.count("error")}" '
+        f'skipped="{outcomes.count("skipped")}" '
+        f'time="{total_time:.3f}">'
     )
 
     for test, outcome, exc_type, message, elapsed in result.records:
-        test_id = test.id()
-        classname, _, name = test_id.rpartition(".")
-        testcase = ET.SubElement(
-            testsuite,
-            "testcase",
-            {"name": name, "classname": classname, "time": f"{elapsed:.3f}"},
+        classname, _, name = test.id().rpartition(".")
+        attrs = (
+            f'name="{_xml_escape(name)}" '
+            f'classname="{_xml_escape(classname)}" '
+            f'time="{elapsed:.3f}"'
         )
         if outcome in ("failure", "error"):
-            node = ET.SubElement(
-                testcase, outcome, {"message": _summary_line(message), "type": exc_type}
+            lines.append(f"  <testcase {attrs}>")
+            lines.append(
+                f"    <{outcome} "
+                f'message="{_xml_escape(_summary_line(message))}" '
+                f'type="{_xml_escape(exc_type)}">'
+                f"{_xml_escape(message)}</{outcome}>"
             )
-            node.text = message
+            lines.append("  </testcase>")
         elif outcome == "skipped":
-            ET.SubElement(testcase, "skipped", {"message": message or ""})
+            lines.append(f"  <testcase {attrs}>")
+            lines.append(
+                f'    <skipped message="{_xml_escape(message or "")}"></skipped>'
+            )
+            lines.append("  </testcase>")
+        else:
+            lines.append(f"  <testcase {attrs}></testcase>")
 
-    tree = ET.ElementTree(testsuites)
-    ET.indent(tree)
-    tree.write(output_path, encoding="utf-8", xml_declaration=True)
+    lines.append("</testsuite></testsuites>")
+
+    with open(output_path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
 
 
 def main() -> None:

--- a/bazel/python/tests/stock_data_test.py
+++ b/bazel/python/tests/stock_data_test.py
@@ -3,8 +3,11 @@
 import os
 import random
 import re
+import sys
 import time
+import traceback
 import unittest
+import xml.etree.ElementTree as ET
 
 from bazel.python.src.stock_data import RateLimitError, StockData, StockDataManager
 
@@ -58,9 +61,7 @@ class StockDataTest(unittest.TestCase):
 
     def setUp(self):
         if getattr(self.__class__, "_rate_limited", False):
-            self.fail(
-                "Polygon rate limit hit while fetching grouped daily bars"
-            )
+            self.fail("Polygon rate limit hit while fetching grouped daily bars")
 
     def test_tracked_tickers_configured(self):
         """Test that tracked ticker metadata is internally consistent."""
@@ -89,5 +90,117 @@ def load_tests(loader, tests, pattern):
     return unittest.TestSuite(test_list)
 
 
+class _RecordingResult(unittest.TestResult):
+    """Collects a per-test outcome so each ticker can be emitted as its own JUnit testcase."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+        self._start_times = {}
+
+    def startTest(self, test):
+        super().startTest(test)
+        self._start_times[test] = time.time()
+
+    def _elapsed(self, test):
+        return time.time() - self._start_times.get(test, time.time())
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        self.records.append((test, "success", "", "", self._elapsed(test)))
+
+    def addFailure(self, test, err):
+        super().addFailure(test, err)
+        self.records.append(
+            (test, "failure", err[0].__name__, _format_err(err), self._elapsed(test))
+        )
+
+    def addError(self, test, err):
+        super().addError(test, err)
+        self.records.append(
+            (test, "error", err[0].__name__, _format_err(err), self._elapsed(test))
+        )
+
+    def addSkip(self, test, reason):
+        super().addSkip(test, reason)
+        self.records.append((test, "skipped", "", reason, self._elapsed(test)))
+
+
+def _format_err(err) -> str:
+    return "".join(traceback.format_exception(*err))
+
+
+def _summary_line(message: str) -> str:
+    """Return the final non-empty traceback line, i.e. the 'ExcType: message' summary."""
+    if not message:
+        return ""
+    for line in reversed(message.strip().splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _write_junit_xml(
+    output_path: str, result: _RecordingResult, total_time: float
+) -> None:
+    """Write one <testcase> per ticker so Bazel/Trunk track each ticker as a distinct test."""
+    outcomes = [outcome for _, outcome, _, _, _ in result.records]
+    testsuites = ET.Element("testsuites")
+    testsuite = ET.SubElement(
+        testsuites,
+        "testsuite",
+        {
+            "name": "StockDataTest",
+            "tests": str(len(result.records)),
+            "failures": str(outcomes.count("failure")),
+            "errors": str(outcomes.count("error")),
+            "skipped": str(outcomes.count("skipped")),
+            "time": f"{total_time:.3f}",
+        },
+    )
+
+    for test, outcome, exc_type, message, elapsed in result.records:
+        test_id = test.id()
+        classname, _, name = test_id.rpartition(".")
+        testcase = ET.SubElement(
+            testsuite,
+            "testcase",
+            {"name": name, "classname": classname, "time": f"{elapsed:.3f}"},
+        )
+        if outcome in ("failure", "error"):
+            node = ET.SubElement(
+                testcase, outcome, {"message": _summary_line(message), "type": exc_type}
+            )
+            node.text = message
+        elif outcome == "skipped":
+            ET.SubElement(testcase, "skipped", {"message": message or ""})
+
+    tree = ET.ElementTree(testsuites)
+    ET.indent(tree)
+    tree.write(output_path, encoding="utf-8", xml_declaration=True)
+
+
+def main() -> None:
+    # Bazel sets XML_OUTPUT_FILE and, when the test does not populate it, falls back
+    # to a single synthesized testcase for the whole target. Emit our own JUnit XML so
+    # every ticker surfaces as an individual test.
+    xml_output_file = os.environ.get("XML_OUTPUT_FILE")
+    if not xml_output_file:
+        unittest.main()
+        return
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(StockDataTest)
+    ordered = list(suite)
+    random.shuffle(ordered)
+
+    result = _RecordingResult()
+    started = time.time()
+    unittest.TestSuite(ordered).run(result)
+    _write_junit_xml(xml_output_file, result, time.time() - started)
+
+    sys.exit(0 if result.wasSuccessful() else 1)
+
+
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,10 @@
 export default [
   {
+    files: ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.ts"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
     rules: {
       semi: "error",
       "prefer-const": "error",

--- a/javascript/tests/playwright/retries.spec.ts
+++ b/javascript/tests/playwright/retries.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * These tests are intentionally broken so the Flake Farm produces JUnit output
+ * that exercises Trunk's flaky-test detection. Retries are forced on here so the
+ * failing cases below are attempted multiple times regardless of the CI env, and
+ * the reporter is configured with `includeRetries: true` so every attempt shows
+ * up in tests/playwright/junitresults-playwright.xml.
+ */
+test.describe('playwright retries', () => {
+  // Force retries even when not running under CI so we always emit retry data.
+  test.describe.configure({ retries: 2 });
+
+  test('fails on every retry', async ({ page }) => {
+    await page.goto('https://playwright.dev/');
+
+    // Assertion failure ("Playwroght" is a typo): reported as a JUnit <failure>.
+    // Retried twice and still fails, producing retry entries in the XML.
+    await expect(page).toHaveTitle('Playwroght');
+  });
+
+  test('flakes intermittently across retries', async ({ page }) => {
+    await page.goto('https://playwright.dev/');
+
+    // Time-based coin flip: passes or fails depending on the wall clock, so the
+    // outcome can differ between the initial attempt and its retries.
+    expect(Date.now() % 2).toBe(0);
+  });
+});
+
+/**
+ * Both of the tests below come from the same technology (Playwright) but land in
+ * JUnit as different result types: one as a <failure> (a failed assertion) and
+ * one as an <error> (an uncaught exception thrown outside of an expect).
+ */
+test.describe('playwright error vs failure', () => {
+  test.describe.configure({ retries: 2 });
+
+  test('failure: assertion does not hold', async ({ page }) => {
+    await page.goto('https://playwright.dev/');
+
+    // Assertion failure -> JUnit <failure>.
+    await expect(page.getByRole('heading', { name: 'Nonexistent Heading' })).toBeVisible({ timeout: 2000 });
+  });
+
+  test('error: throws an uncaught exception', async () => {
+    // Thrown exception (not an expect assertion) -> JUnit <error>.
+    // JSON.parse throws a SyntaxError before any expect() runs.
+    const data = JSON.parse('{ this is not valid json }');
+    expect(data).toBeTruthy();
+  });
+});

--- a/javascript/tests/playwright/retries.spec.ts
+++ b/javascript/tests/playwright/retries.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 /**
  * These tests are intentionally broken so the Flake Farm produces JUnit output
@@ -7,20 +7,20 @@ import { test, expect } from '@playwright/test';
  * the reporter is configured with `includeRetries: true` so every attempt shows
  * up in tests/playwright/junitresults-playwright.xml.
  */
-test.describe('playwright retries', () => {
+test.describe("playwright retries", () => {
   // Force retries even when not running under CI so we always emit retry data.
   test.describe.configure({ retries: 2 });
 
-  test('fails on every retry', async ({ page }) => {
-    await page.goto('https://playwright.dev/');
+  test("fails on every retry", async ({ page }) => {
+    await page.goto("https://playwright.dev/");
 
     // Assertion failure ("Playwroght" is a typo): reported as a JUnit <failure>.
     // Retried twice and still fails, producing retry entries in the XML.
-    await expect(page).toHaveTitle('Playwroght');
+    await expect(page).toHaveTitle("Playwroght");
   });
 
-  test('flakes intermittently across retries', async ({ page }) => {
-    await page.goto('https://playwright.dev/');
+  test("flakes intermittently across retries", async ({ page }) => {
+    await page.goto("https://playwright.dev/");
 
     // Time-based coin flip: passes or fails depending on the wall clock, so the
     // outcome can differ between the initial attempt and its retries.
@@ -33,20 +33,22 @@ test.describe('playwright retries', () => {
  * JUnit as different result types: one as a <failure> (a failed assertion) and
  * one as an <error> (an uncaught exception thrown outside of an expect).
  */
-test.describe('playwright error vs failure', () => {
+test.describe("playwright error vs failure", () => {
   test.describe.configure({ retries: 2 });
 
-  test('failure: assertion does not hold', async ({ page }) => {
-    await page.goto('https://playwright.dev/');
+  test("failure: assertion does not hold", async ({ page }) => {
+    await page.goto("https://playwright.dev/");
 
     // Assertion failure -> JUnit <failure>.
-    await expect(page.getByRole('heading', { name: 'Nonexistent Heading' })).toBeVisible({ timeout: 2000 });
+    await expect(
+      page.getByRole("heading", { name: "Nonexistent Heading" }),
+    ).toBeVisible({ timeout: 2000 });
   });
 
-  test('error: throws an uncaught exception', async () => {
+  test("error: throws an uncaught exception", async () => {
     // Thrown exception (not an expect assertion) -> JUnit <error>.
     // JSON.parse throws a SyntaxError before any expect() runs.
-    const data = JSON.parse('{ this is not valid json }');
+    const data = JSON.parse("{ this is not valid json }");
     expect(data).toBeTruthy();
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.1",
-    "@playwright/test": "^1.48.2",
+    "@playwright/test": "^1.61.1",
     "@tsconfig/node22": "^22.0.0",
     "@types/mocha": "^10.0.9",
     "@types/node": "^20.17.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Read environment variables from file.
@@ -10,7 +10,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './javascript/tests/playwright',
+  testDir: "./javascript/tests/playwright",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -20,35 +20,40 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['junit', {
-    includeProjectInTestName:true,
-    includeRetries:true,
-    outputFile:"tests/playwright/junitresults-playwright.xml"
-  }]],
+  reporter: [
+    [
+      "junit",
+      {
+        includeProjectInTestName: true,
+        includeRetries: true,
+        outputFile: "tests/playwright/junitresults-playwright.xml",
+      },
+    ],
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
 
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
 
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
 
     /* Test against mobile viewports. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['junit', {
     includeProjectInTestName:true,
+    includeRetries:true,
     outputFile:"tests/playwright/junitresults-playwright.xml"
   }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1
       '@playwright/test':
-        specifier: ^1.48.2
-        version: 1.48.2
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tsconfig/node22':
         specifier: ^22.0.0
         version: 22.0.0
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.48.2':
-    resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -464,6 +464,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1150,16 +1151,17 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -1948,13 +1950,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.48.2:
-    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.48.2:
-    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2453,10 +2455,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -3070,9 +3074,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.48.2':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.48.2
+      playwright: 1.61.1
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -4976,11 +4980,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.48.2: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.48.2:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.48.2
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Summary
This PR adds a new Playwright test suite designed to exercise Trunk's flaky-test detection capabilities by intentionally creating tests that fail or flake across retries.

## Key Changes
- **New test file** (`retries.spec.ts`): Added two test suites with intentionally broken tests:
  - `playwright retries`: Tests that fail consistently and tests that flake intermittently based on timing
  - `playwright error vs failure`: Tests that demonstrate both assertion failures and uncaught exceptions
- **Playwright configuration**: Updated `playwright.config.ts` to enable `includeRetries: true` in the JUnit reporter, ensuring all retry attempts are captured in the test results XML
- **Dependency update**: Upgraded `@playwright/test` from `^1.48.2` to `^1.61.1` to support the latest retry reporting features

## Implementation Details
- Tests are configured with `retries: 2` to force multiple attempts regardless of CI environment
- The flaky test uses a time-based coin flip (`Date.now() % 2`) to produce non-deterministic results across retries
- Tests intentionally produce both JUnit `<failure>` entries (assertion failures) and `<error>` entries (uncaught exceptions) to exercise different result types
- All test output is captured in `tests/playwright/junitresults-playwright.xml` for analysis

https://claude.ai/code/session_019tk6V3NTy3p1JcmWiV32cg